### PR TITLE
shift to home page for citation for cleaner look

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -105,5 +105,4 @@ format:
       light: flatly
       dark: cyborg
     css: docs/styles.css
-    license: "CC BY-SA"
-    doi: 10.5281/zenodo.19779578
+

--- a/docs/faq.qmd
+++ b/docs/faq.qmd
@@ -12,6 +12,10 @@ format:
 Have an idea for a common topic to add to this FAQ? Give us a shout! Submit an issue to the project and tag the the issue using the "question" label.
 :::
 
+# How do I cite the project?
+
+Information on how to cite the project is available [on the home page](/docs/index.qmd#citation).
+
 # How do I register a dataset to the catalogue (or recommend a dataset be registered)?
 
 Check out the detailed guidance on [in the contributing section](/docs/catalogue/contributing.qmd).
@@ -38,3 +42,4 @@ Create [a new issue](https://github.com/UN-Task-Team-for-Scanner-Data/reproducib
 ## Option 2: Contact us directly
 
 Check out the [about the team section](/docs/about.qmd) for our info. The project lead's email will be included if you wish to use it.
+

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -2,6 +2,25 @@
 title: "Welcome to the Price Statistics Reproducibility Project"
 date: 2025-04-28
 date-format: YYYY-MM-DD
+citation:
+  title: Price Statistics Reproducibility Project
+  author: 
+    - name: Serge Goussev
+      orcid: 0009-0008-2359-5322
+    - name: Steve Martin
+      orcid: 0000-0003-2544-  9480
+    - name: Claude Lamboray
+    - name: Christophe Bontemps
+    - name: Tanya Flower
+    - name: Ben Hillman
+    - name: Caroline White
+    - name: Jens Mehrhoff
+  type: paper-conference
+  container-title: "Presented at the 19th Ottawa Group meeting, Warsaw, Poland"
+  available-date: 2026/05/14
+  url: https://un-task-team-for-scanner-data.github.io/reproducibility-project/docs/
+  doi: 10.5281/zenodo.19779578
+  issued: 2026-05-14
 format:
   html:
     toc: true


### PR DESCRIPTION
A few ideas/changes:
- [x] Shift to cleaner "citation" at the bottom of the home page. DOIs and licence everywhere is a bit too cluttered
- [ ] Refresh metadata page
- [ ] Refresh licences page